### PR TITLE
Detach block hash from sender chain

### DIFF
--- a/contracts/SenderChain.sol
+++ b/contracts/SenderChain.sol
@@ -3,27 +3,20 @@ pragma solidity >=0.4.22 <0.9.0;
 
 
 library SenderChain {
+    // Feel free to add more return values
     function getBlockHeaderFields(
         bytes memory blockHeader
     ) public pure returns(
-        bytes32 prevBlockHash,
         uint256 blockNumber
     ) {
         bytes32 blockNumberBytes;
-        // prevBlockHash is located at bytes 32 + [0:32] and blockNumber
-        // is located at 32 + [468:500] because we need to skip the first
-        // 32 bytes (reserved for the length of the byte string).
+        // blockNumber is located at 32 + [468:500] because we
+        // need to skip the first 32 bytes (reserved for the
+        // length of the byte string).
         /* solium-disable-next-line */
         assembly {
-            prevBlockHash := mload(add(blockHeader, 32))
             blockNumberBytes := mload(add(blockHeader, 500))
         }
         blockNumber = uint256(blockNumberBytes);
-    }
-
-    function getBlockHeaderHash(
-        bytes memory blockHeader
-    ) public pure returns(bytes32) {
-        return keccak256(blockHeader);
     }
 }

--- a/contracts/UpdaterContractWithSkip.sol
+++ b/contracts/UpdaterContractWithSkip.sol
@@ -34,7 +34,7 @@ contract UpdaterContractWithSkip {
         bytes memory syncCommitteeProof
     ) public returns(bool) {
         // Check if parent exists
-        bytes32 prevHash = SenderChain.getBlockHeaderHash(prevBlockHeader);
+        bytes32 prevHash = keccak256(prevBlockHeader);
         headerInfo memory prevEntry = headerDAG[prevHash];
         if (!prevEntry.exists) {
             if (!headerDAGEmpty) {
@@ -44,7 +44,6 @@ contract UpdaterContractWithSkip {
         }
 
         (
-            bytes32 prevBlockHash,
             uint256 blockNumber
         ) = SenderChain.getBlockHeaderFields(currBlockHeader);
 
@@ -78,10 +77,10 @@ contract UpdaterContractWithSkip {
         }
 
         // Update state
-        bytes32 currHash = SenderChain.getBlockHeaderHash(currBlockHeader);
+        bytes32 currHash = keccak256(currBlockHeader);
         // TODO Handle block number conflicts
         headerDAG[currHash].exists = true;
-        headerDAG[currHash].prevBlockHash = prevBlockHash;
+        headerDAG[currHash].prevBlockHash = prevHash;
         numberToHeader[blockNumber].exists = true;
         numberToHeader[blockNumber].blockHeader = currBlockHeader;
         numberToHeader[blockNumber].proof = proof;

--- a/test/updater_contract.js
+++ b/test/updater_contract.js
@@ -7,37 +7,24 @@ const SenderChain = artifacts.require("SenderChain");
  * See docs: https://www.trufflesuite.com/docs/truffle/testing/writing-tests-in-javascript
  */
 contract("UpdaterContract", function (accounts) {
-    it("getBlockHeaderFields and getBlockHeaderHash", async function () {
+    it("getBlockHeaderFields", async function () {
         const senderChain = await SenderChain.deployed();
 
         // Create fake block header 1
         const blockHeaderByteArray1 = new Uint8Array(600);
         blockHeaderByteArray1[499] = 1;
 
-        const {0: prevBlockHash1, 1: blockNumber1} = await
+        const blockNumber1 = await
             senderChain.getBlockHeaderFields.call(blockHeaderByteArray1);
         assert.equal(blockNumber1, 1);
 
-        // Compute hash
-        var blockHeaderHash1 = web3.utils.soliditySha3(
-            web3.utils.bytesToHex(blockHeaderByteArray1));
-        var blockHeaderHashBytes1 = web3.utils.hexToBytes(blockHeaderHash1);
-
         // Create fake block header 2
         const blockHeaderByteArray2 = new Uint8Array(600);
-        for (let i = 0; i < 32; i++) {
-            blockHeaderByteArray2[i] = blockHeaderHashBytes1[i];
-        }
         blockHeaderByteArray2[499] = 2;
 
-        const {0: prevBlockHash2, 1: blockNumber2} = await
+        const blockNumber2 = await
             senderChain.getBlockHeaderFields.call(blockHeaderByteArray2);
         assert.equal(blockNumber2, 2);
-        assert.equal(prevBlockHash2, blockHeaderHash1);
-
-        const solComputedHash = await
-            senderChain.getBlockHeaderHash.call(blockHeaderByteArray1);
-        assert.equal(solComputedHash, blockHeaderHash1);
     });
     it("headerUpdate and getBlockHeader sanity", async function () {
         const updaterContract = await UpdaterContract.deployed();
@@ -60,16 +47,8 @@ contract("UpdaterContract", function (accounts) {
         assert.isTrue(success1);
         assert.equal(getBlockHeader1, web3.utils.bytesToHex(blockHeaderByteArray1));
 
-        // Compute block header 1 hash
-        var blockHeaderHash1 = web3.utils.soliditySha3(
-            web3.utils.bytesToHex(blockHeaderByteArray1));
-        var blockHeaderHashBytes1 = web3.utils.hexToBytes(blockHeaderHash1);
-
         // Create fake block header 2
         const blockHeaderByteArray2 = new Uint8Array(600);
-        for (let i = 0; i < 32; i++) {
-            blockHeaderByteArray2[i] = blockHeaderHashBytes1[i];
-        }
         blockHeaderByteArray2[499] = 2;
 
         var success2 = await updaterContract.headerUpdate.call(
@@ -126,16 +105,8 @@ contract("UpdaterContract", function (accounts) {
         assert.isTrue(success1);
         assert.equal(getBlockHeader1, web3.utils.bytesToHex(blockHeaderByteArray1));
 
-        // Compute block header 1 hash
-        var blockHeaderHash1 = web3.utils.soliditySha3(
-            web3.utils.bytesToHex(blockHeaderByteArray1));
-        var blockHeaderHashBytes1 = web3.utils.hexToBytes(blockHeaderHash1);
-
         // Create fake block header 2
         const blockHeaderByteArray2 = new Uint8Array(600);
-        for (let i = 0; i < 32; i++) {
-            blockHeaderByteArray2[i] = blockHeaderHashBytes1[i];
-        }
         blockHeaderByteArray2[499] = 2;
 
         var success2 = await updaterContractWithSkip.headerUpdate.call(


### PR DESCRIPTION
<!-- Describe PR -->
The updater contract assumes that the hashes it computes are computed in the same way as the sender chain (consequently, the updater contract assumes that block headers are formatted canonically). This pr removes this assumption.

Tested:

- [x] `solium -d .`
- [x] `truffle test` (+ no compiler warnings)
