### PR TITLE
Change blockheader from bytes to struct

### DIFF
--- a/contracts/LightClient.sol
+++ b/contracts/LightClient.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.4.22 <0.9.0;
 
+import "./SenderChain.sol";
 
 library LightClient {
     struct lightClientState {
@@ -9,8 +10,8 @@ library LightClient {
 
     function update(
         lightClientState storage LCS,
-        bytes memory /* currBlockHeader */,
-        bytes memory /* prevBlockHeader */
+        SenderChain.bh memory /* currBlockHeader */,
+        SenderChain.bh memory /* prevBlockHeader */
     ) public {
         LCS.notImplemented = true;
     }
@@ -18,8 +19,8 @@ library LightClient {
     function verify(
         bytes memory /* proof */,
         lightClientState storage LCS,
-        bytes memory /* currBlockHeader */,
-        bytes memory /* prevBlockHeader */
+        SenderChain.bh memory /* currBlockHeader */,
+        SenderChain.bh memory /* prevBlockHeader */
     ) public view returns(bool) {
         // Read LCS to prevent compiler telling us to change view -> pure
         // Dummy implementation always returns true
@@ -29,7 +30,7 @@ library LightClient {
     function verifyBatch(
         bytes memory /* proof */,
         lightClientState storage LCS,
-        bytes[] memory /* headers */
+        SenderChain.bh[] memory /* headers */
     ) public view returns(bool) {
         // Read LCS to prevent compiler telling us to change view -> pure
         // Dummy implementation always returns true

--- a/contracts/LightClient.sol
+++ b/contracts/LightClient.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.4.22 <0.9.0;
 
 import "./SenderChain.sol";
 
+
 library LightClient {
     struct lightClientState {
         bool notImplemented;

--- a/contracts/LightClientWithSkip.sol
+++ b/contracts/LightClientWithSkip.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.4.22 <0.9.0;
 
+import "./SenderChain.sol";
+
 
 library LightClientWithSkip {
     struct lightClientState {
@@ -9,8 +11,8 @@ library LightClientWithSkip {
 
     function update(
         lightClientState storage LCS,
-        bytes memory /* currBlockHeader */,
-        bytes memory /* prevBlockHeader */,
+        SenderChain.bh memory /* currBlockHeader */,
+        SenderChain.bh memory /* prevBlockHeader */,
         bytes memory /* syncCommittee */,
         bytes memory /* syncCommitteeProof */
     ) public {
@@ -20,8 +22,8 @@ library LightClientWithSkip {
     function verify(
         bytes memory /* proof */,
         lightClientState storage LCS,
-        bytes memory /* currBlockHeader */,
-        bytes memory /* prevBlockHeader */,
+        SenderChain.bh memory /* currBlockHeader */,
+        SenderChain.bh memory /* prevBlockHeader */,
         bytes memory /* syncCommittee */,
         bytes memory /* syncCommitteeProof */
     ) public view returns(bool) {

--- a/contracts/Merkle.sol
+++ b/contracts/Merkle.sol
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.4.22 <0.9.0;
 
+import "./SenderChain.sol";
+
 
 // Common functions used by both UpdaterContract and UpdaterContractWithSkip
 library Merkle {
     function verifyMessage(
-        bytes memory /* blockHeader */,
+        SenderChain.bh memory /* blockHeader */,
         bytes memory /* message */,
         bytes memory /* merkleProof */
     ) public pure returns(bool) {

--- a/contracts/SenderChain.sol
+++ b/contracts/SenderChain.sol
@@ -3,20 +3,29 @@ pragma solidity >=0.4.22 <0.9.0;
 
 
 library SenderChain {
+    struct bh {
+        uint256 blockNumber;
+        bytes asBytes;
+    }
+
     // Feel free to add more return values
     function getBlockHeaderFields(
-        bytes memory blockHeader
+        bh memory blockHeader
     ) public pure returns(
         uint256 blockNumber
     ) {
-        bytes32 blockNumberBytes;
-        // blockNumber is located at 32 + [468:500] because we
-        // need to skip the first 32 bytes (reserved for the
-        // length of the byte string).
-        /* solium-disable-next-line */
-        assembly {
-            blockNumberBytes := mload(add(blockHeader, 500))
-        }
-        blockNumber = uint256(blockNumberBytes);
+        return blockHeader.blockNumber;
+    }
+
+    function getBlockHeaderHash(
+        bh memory blockHeader
+    ) public pure returns(bytes32) {
+        return keccak256(blockHeader.asBytes);
+    }
+
+    function getBlockHeaderBytes(
+        bh memory blockHeader
+    ) public pure returns(bytes memory) {
+        return blockHeader.asBytes;
     }
 }

--- a/contracts/UpdaterContract.sol
+++ b/contracts/UpdaterContract.sol
@@ -22,6 +22,7 @@ contract UpdaterContract {
 
     event LogMe(string message);
 
+    // Convenient preprocessing function that sits on top of headerUpdateCore
     function headerUpdate(
         bytes memory proof,
         uint256 currBlockNumber,

--- a/contracts/UpdaterContract.sol
+++ b/contracts/UpdaterContract.sol
@@ -12,7 +12,7 @@ contract UpdaterContract {
     struct headerInfo {
         bool exists;
         bytes32 prevBlockHash;
-        bytes blockHeader;
+        SenderChain.bh blockHeader;
         bytes proof;
     }
     mapping (bytes32 => headerInfo) headerDAG;
@@ -24,11 +24,27 @@ contract UpdaterContract {
 
     function headerUpdate(
         bytes memory proof,
+        uint256 currBlockNumber,
         bytes memory currBlockHeader,
+        uint256 prevBlockNumber,
         bytes memory prevBlockHeader
     ) public returns(bool) {
+        SenderChain.bh memory curr;
+        SenderChain.bh memory prev;
+        curr.asBytes = currBlockHeader;
+        curr.blockNumber = currBlockNumber;
+        prev.asBytes = prevBlockHeader;
+        prev.blockNumber = prevBlockNumber;
+        return headerUpdateCore(proof, curr, prev);
+    }
+
+    function headerUpdateCore(
+        bytes memory proof,
+        SenderChain.bh memory currBlockHeader,
+        SenderChain.bh memory prevBlockHeader
+    ) public returns(bool) {
         // Check if parent exists
-        bytes32 prevHash = keccak256(prevBlockHeader);
+        bytes32 prevHash = SenderChain.getBlockHeaderHash(prevBlockHeader);
         headerInfo memory prevEntry = headerDAG[prevHash];
         if (!prevEntry.exists) {
             if (!headerDAGEmpty) {
@@ -52,7 +68,7 @@ contract UpdaterContract {
         LightClient.update(LCS, currBlockHeader, prevBlockHeader);
 
         // Update state
-        bytes32 currHash = keccak256(currBlockHeader);
+        bytes32 currHash = SenderChain.getBlockHeaderHash(currBlockHeader);
         // TODO Handle block number conflicts
         headerDAG[currHash].exists = true;
         headerDAG[currHash].prevBlockHash = prevHash;
@@ -63,12 +79,12 @@ contract UpdaterContract {
         return true;
     }
 
-    function batchedHeaderUpdate(
+    function batchedHeaderUpdateCore(
         bytes memory proof,
-        bytes[] memory headers
+        SenderChain.bh[] memory headers
     ) public returns(bool) {
         // Check if first block exists
-        bytes32 prevHash = keccak256(headers[0]);
+        bytes32 prevHash = SenderChain.getBlockHeaderHash(headers[0]);
         headerInfo memory prevEntry = headerDAG[prevHash];
         if (!prevEntry.exists) {
             if (!headerDAGEmpty) {
@@ -83,7 +99,7 @@ contract UpdaterContract {
 
         // Update state
         for (uint256 i = 1; i < headers.length; i++) {
-            bytes32 currHash = keccak256(headers[i]);
+            bytes32 currHash = SenderChain.getBlockHeaderHash(headers[i]);
             (
                 uint256 blockNumber
             ) = SenderChain.getBlockHeaderFields(headers[i]);
@@ -104,7 +120,8 @@ contract UpdaterContract {
         LightClient.lightClientState memory _LCS
     ) {
         success = numberToHeader[blockNumber].exists;
-        blockHeader = numberToHeader[blockNumber].blockHeader;
+        blockHeader = SenderChain.getBlockHeaderBytes(
+            numberToHeader[blockNumber].blockHeader);
         _LCS = LCS;
     }
 }

--- a/migrations/1_deploy_contracts.js
+++ b/migrations/1_deploy_contracts.js
@@ -7,15 +7,21 @@ const UpdaterContractWithSkip = artifacts.require("UpdaterContractWithSkip");
 
 module.exports = function(deployer) {
     deployer.deploy(SenderChain);
+
+    deployer.link(SenderChain, Merkle);
     deployer.deploy(Merkle);
 
+    deployer.link(SenderChain, LightClient);
     deployer.deploy(LightClient);
+
     deployer.link(LightClient, UpdaterContract);
     deployer.link(SenderChain, UpdaterContract);
     deployer.link(Merkle, UpdaterContract);
     deployer.deploy(UpdaterContract);
 
+    deployer.link(SenderChain, LightClientWithSkip);
     deployer.deploy(LightClientWithSkip);
+
     deployer.link(LightClientWithSkip, UpdaterContractWithSkip);
     deployer.link(SenderChain, UpdaterContractWithSkip);
     deployer.link(Merkle, UpdaterContractWithSkip);

--- a/test/updater_contract.js
+++ b/test/updater_contract.js
@@ -7,25 +7,6 @@ const SenderChain = artifacts.require("SenderChain");
  * See docs: https://www.trufflesuite.com/docs/truffle/testing/writing-tests-in-javascript
  */
 contract("UpdaterContract", function (accounts) {
-    it("getBlockHeaderFields", async function () {
-        const senderChain = await SenderChain.deployed();
-
-        // Create fake block header 1
-        const blockHeaderByteArray1 = new Uint8Array(600);
-        blockHeaderByteArray1[499] = 1;
-
-        const blockNumber1 = await
-            senderChain.getBlockHeaderFields.call(blockHeaderByteArray1);
-        assert.equal(blockNumber1, 1);
-
-        // Create fake block header 2
-        const blockHeaderByteArray2 = new Uint8Array(600);
-        blockHeaderByteArray2[499] = 2;
-
-        const blockNumber2 = await
-            senderChain.getBlockHeaderFields.call(blockHeaderByteArray2);
-        assert.equal(blockNumber2, 2);
-    });
     it("headerUpdate and getBlockHeader sanity", async function () {
         const updaterContract = await UpdaterContract.deployed();
 
@@ -37,10 +18,10 @@ contract("UpdaterContract", function (accounts) {
         blockHeaderByteArray1[499] = 1;
 
         var success1 = await updaterContract.headerUpdate.call(
-            new Uint8Array(0), blockHeaderByteArray1, blockHeaderByteArray0);
+            new Uint8Array(0), 1, blockHeaderByteArray1, 0, blockHeaderByteArray0);
         assert.isTrue(success1);
         await updaterContract.headerUpdate(new Uint8Array(0),
-            blockHeaderByteArray1, blockHeaderByteArray0);
+            1, blockHeaderByteArray1, 0, blockHeaderByteArray0);
 
         var {0: success1, 1: getBlockHeader1, 2: lcs1} =
             await updaterContract.getBlockHeader.call(1);
@@ -52,10 +33,10 @@ contract("UpdaterContract", function (accounts) {
         blockHeaderByteArray2[499] = 2;
 
         var success2 = await updaterContract.headerUpdate.call(
-            new Uint8Array(0), blockHeaderByteArray2, blockHeaderByteArray1);
+            new Uint8Array(0), 2, blockHeaderByteArray2, 1, blockHeaderByteArray1);
         assert.isTrue(success2);
         await updaterContract.headerUpdate(new Uint8Array(0),
-            blockHeaderByteArray2, blockHeaderByteArray1);
+            2, blockHeaderByteArray2, 1, blockHeaderByteArray1);
 
         var {0: success2, 1: getBlockHeader2, 2: lcs2} =
             await updaterContract.getBlockHeader.call(2);
@@ -64,10 +45,10 @@ contract("UpdaterContract", function (accounts) {
 
         // Try to add bad parent block
         var bad = await updaterContract.headerUpdate.call(
-            new Uint8Array(0), blockHeaderByteArray1, blockHeaderByteArray0);
+            new Uint8Array(0), 1, blockHeaderByteArray1, 0, blockHeaderByteArray0);
         assert.isFalse(bad);
         await updaterContract.headerUpdate(new Uint8Array(0),
-            blockHeaderByteArray1, blockHeaderByteArray0);
+            1, blockHeaderByteArray1, 0, blockHeaderByteArray0);
 
         var {0: bad, 1: getBlockHeader0, 2: lcs0} =
             await updaterContract.getBlockHeader.call(0);
@@ -86,7 +67,9 @@ contract("UpdaterContract", function (accounts) {
 
         var success1 = await updaterContractWithSkip.headerUpdate.call(
             new Uint8Array(0),
+            1,
             blockHeaderByteArray1,
+            0,
             blockHeaderByteArray0,
             new Uint8Array(0),
             new Uint8Array(0)
@@ -94,7 +77,9 @@ contract("UpdaterContract", function (accounts) {
         assert.isTrue(success1);
         await updaterContractWithSkip.headerUpdate(
             new Uint8Array(0),
+            1,
             blockHeaderByteArray1,
+            0,
             blockHeaderByteArray0,
             new Uint8Array(0),
             new Uint8Array(0)
@@ -111,7 +96,9 @@ contract("UpdaterContract", function (accounts) {
 
         var success2 = await updaterContractWithSkip.headerUpdate.call(
             new Uint8Array(0),
+            2,
             blockHeaderByteArray2,
+            1,
             blockHeaderByteArray1,
             new Uint8Array(0),
             new Uint8Array(0)
@@ -119,7 +106,9 @@ contract("UpdaterContract", function (accounts) {
         assert.isTrue(success2);
         await updaterContractWithSkip.headerUpdate(
             new Uint8Array(0),
+            2,
             blockHeaderByteArray2,
+            1,
             blockHeaderByteArray1,
             new Uint8Array(0),
             new Uint8Array(0)
@@ -133,7 +122,9 @@ contract("UpdaterContract", function (accounts) {
         // Try to add bad parent block
         var bad = await updaterContractWithSkip.headerUpdate.call(
             new Uint8Array(0),
+            1,
             blockHeaderByteArray1,
+            0,
             blockHeaderByteArray0,
             new Uint8Array(0),
             new Uint8Array(0)
@@ -141,7 +132,9 @@ contract("UpdaterContract", function (accounts) {
         assert.isFalse(bad);
         await updaterContractWithSkip.headerUpdate(
             new Uint8Array(0),
+            1,
             blockHeaderByteArray1,
+            0,
             blockHeaderByteArray0,
             new Uint8Array(0),
             new Uint8Array(0)


### PR DESCRIPTION
<!-- Describe PR -->

Change block header from bytes to struct. This allows us to pass in the blockNumber to headerUpdate, which allows us to avoid deserialization. We still keep the original headerUpdate function, but we rename it to headerUpdateCore.

Tested:

- [x] `solium -d .`
- [x] `truffle test` (+ no compiler warnings)
